### PR TITLE
Ceil div

### DIFF
--- a/wsidicom/geometry.py
+++ b/wsidicom/geometry.py
@@ -183,7 +183,7 @@ class Size:
             )
         return NotImplemented
 
-    def __truediv__(self, divider: Union[int, 'Size', SizeMm]) -> 'Size':
+    def ceil_div(self, divider: Union[int, 'Size', SizeMm]) -> 'Size':
         if isinstance(divider, (int, float)):
             return Size(
                 math.ceil(self.width/divider),
@@ -270,7 +270,7 @@ class Point:
             return Point(int(self.x/divider.width), int(self.y/divider.height))
         return NotImplemented
 
-    def __truediv__(self, divider: Union[int, float, Size, SizeMm]) -> 'Point':
+    def ceil_div(self, divider: Union[int, float, Size, SizeMm]) -> 'Point':
         if isinstance(divider, (int, float)):
             return Point(
                 math.ceil(self.x/divider),

--- a/wsidicom/instance.py
+++ b/wsidicom/instance.py
@@ -1273,7 +1273,7 @@ class ImageData(metaclass=ABCMeta):
     def tiled_size(self) -> Size:
         """The size of the image when divided into tiles, e.g. number of
         columns and rows of tiles. Equals (1, 1) if image is not tiled."""
-        return self.image_size / self.tile_size
+        return self.image_size.ceil_div(self.tile_size)
 
     @property
     def image_region(self) -> Region:
@@ -1711,7 +1711,7 @@ class ImageData(metaclass=ABCMeta):
             Region of tiles for stitching image
         """
         start = pixel_region.start // self.tile_size
-        end = pixel_region.end / self.tile_size - 1
+        end = pixel_region.end.ceil_div(self.tile_size) - 1
         tile_region = Region.from_points(start, end)
         if not self.valid_tiles(tile_region, z, path):
             raise WsiDicomOutOfBoundsError(
@@ -2133,7 +2133,7 @@ class TileIndex(metaclass=ABCMeta):
         self._tile_size = base_dataset.tile_size
         self._frame_count = self._read_frame_count_from_datasets(datasets)
         self._optical_paths = self._read_optical_paths_from_datasets(datasets)
-        self._tiled_size = self.image_size / self.tile_size
+        self._tiled_size = self.image_size.ceil_div(self.tile_size)
 
     def __str__(self) -> str:
         return (
@@ -2996,7 +2996,7 @@ class WsiDicomFileWriter(MetaWsiDicomFile):
             minimum_chunk_size,
             chunk_size//minimum_chunk_size * minimum_chunk_size
         )
-        new_tiled_size = image_data.tiled_size / scale
+        new_tiled_size = image_data.tiled_size.ceil_div(scale)
         # Divide the image tiles up into chunk_size chunks (up to tiled size)
         chunked_tile_points = (
             Region(

--- a/wsidicom/wsidicom.py
+++ b/wsidicom/wsidicom.py
@@ -765,7 +765,7 @@ class WsiDicomLevel(WsiDicomGroup):
                 f"Region {cropped_region}", f"level size {self.size}"
             )
         image = self.get_region(cropped_region, z, path)
-        tile_size = cropped_region.size/scale
+        tile_size = cropped_region.size.ceil_div(scale)
         image = image.resize(
             tile_size.to_tuple(),
             resample=Image.BILINEAR


### PR DESCRIPTION
Remove __truediv__, that worked like "ceil div" from Size and Point, and use new ceil_div() instead.
Fix bug for calculating number of frames when creating a scaled down level.