### PR TITLE
Mark test in test_annotation.py as annotation tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ markers =
     unittest: add a test as a unittest
     integration: add a test as a integration test
     save: add a test as a save test
+    annotation: add a test as an annotation test

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -52,7 +52,7 @@ slide_uids = SlideUids(
 )
 
 
-@pytest.mark.unittest
+@pytest.mark.annotation
 class WsiDicomAnnotationTests(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Test in test_annotations.py require test data that is not yet in the repo. Mark it as annotation test so that tests marked unittest can run without test data.