### PR TITLE
Allow attributes to be missing for some image types

### DIFF
--- a/test/test_save.py
+++ b/test/test_save.py
@@ -161,7 +161,7 @@ class WsiDicomFileSaveTests(unittest.TestCase):
         image_data: WsiDicomTestImageData
     ):
         dataset = Dataset()
-        dataset.SOPClassUID = UID(WSI_SOP_CLASS_UID)
+        dataset.SOPClassUID = WSI_SOP_CLASS_UID
         dataset.ImageType = [
             'ORGINAL', 'PRIMARY', 'VOLUME', 'NONE'
         ]
@@ -214,7 +214,7 @@ class WsiDicomFileSaveTests(unittest.TestCase):
     def test_write_meta(self):
         transfer_syntax = JPEGBaseline8Bit
         instance_uid = generate_uid()
-        class_uid = UID(WSI_SOP_CLASS_UID)
+        class_uid = WSI_SOP_CLASS_UID
         with TemporaryDirectory() as tempdir:
             filepath = Path(tempdir + '/1.dcm')
             with WsiDicomFileWriter(filepath) as write_file:

--- a/wsidicom/errors.py
+++ b/wsidicom/errors.py
@@ -78,3 +78,11 @@ class WsiDicomOutOfBoundsError(Exception):
 
     def __str__(self):
         return f"{self.error} is out of bonds of {self.bonds}"
+
+
+class WsiDicomStrictRequirementError(Exception):
+    """Raised if attribute required in strict mode is missing."""
+
+
+class WsiDicomRequirementError(Exception):
+    """Raised if required attribute is missing."""

--- a/wsidicom/geometry.py
+++ b/wsidicom/geometry.py
@@ -183,7 +183,7 @@ class Size:
             )
         return NotImplemented
 
-    def __truediv__(self, divider: Union[int, 'Size', SizeMm]) -> 'Size':
+    def ceil_div(self, divider: Union[int, 'Size', SizeMm]) -> 'Size':
         if isinstance(divider, (int, float)):
             return Size(
                 math.ceil(self.width/divider),
@@ -270,7 +270,7 @@ class Point:
             return Point(int(self.x/divider.width), int(self.y/divider.height))
         return NotImplemented
 
-    def __truediv__(self, divider: Union[int, float, Size, SizeMm]) -> 'Point':
+    def ceil_div(self, divider: Union[int, float, Size, SizeMm]) -> 'Point':
         if isinstance(divider, (int, float)):
             return Point(
                 math.ceil(self.x/divider),

--- a/wsidicom/graphical_annotations.py
+++ b/wsidicom/graphical_annotations.py
@@ -34,7 +34,7 @@ from pydicom.uid import (ExplicitVRBigEndian, ExplicitVRLittleEndian,
 from pydicom.values import convert_numbers
 
 from .geometry import PointMm, RegionMm, SizeMm
-from .uid import ANN_SOP_CLASS_UID, SlideUids, Uid
+from .uid import ANN_SOP_CLASS_UID, SlideUids, UID
 
 config.enforce_valid_values = True
 config.future_behavior()
@@ -967,7 +967,7 @@ class AnnotationGroup:
         description: Optional[str] = None,
         color: Optional[LabColor] = None,
         is_double: bool = True,
-        instance: Optional[Uid] = None
+        instance: Optional[UID] = None
     ):
         """Represents a group of annotations of the same type.
 
@@ -1102,7 +1102,7 @@ class AnnotationGroup:
     def from_ds(
         cls,
         ds: Dataset,
-        instance: Uid
+        instance: UID
     ) -> 'AnnotationGroup':
         """Return annotation group from Annotation Group Sequence dataset.
 
@@ -1933,7 +1933,7 @@ class AnnotationInstance:
         path: Union[str, Path],
         little_endian: bool = True,
         implicit_vr: bool = False,
-        uid_generator: Callable[..., Uid] = generate_uid
+        uid_generator: Callable[..., UID] = generate_uid
     ):
         """Write annotations to DICOM file according to sup 222.
         Note that the file will miss DICOM attributes that has not yet been
@@ -1983,7 +1983,7 @@ class AnnotationInstance:
 
         meta_ds.TransferSyntaxUID = transfer_syntax
         meta_ds.MediaStorageSOPInstanceUID = ds.SOPInstanceUID
-        meta_ds.MediaStorageSOPClassUID = Uid(ANN_SOP_CLASS_UID)
+        meta_ds.MediaStorageSOPClassUID = ANN_SOP_CLASS_UID
         meta_ds.FileMetaInformationGroupLength = 0  # Updated on write
         validate_file_meta(meta_ds)
         file_ds = FileDataset(

--- a/wsidicom/instance.py
+++ b/wsidicom/instance.py
@@ -29,6 +29,7 @@ from typing import (Any, BinaryIO, Dict, Generator, List, Optional,
 
 import numpy as np
 from PIL import Image
+from pydicom import FileDataset
 from pydicom.dataset import Dataset, FileMetaDataset, validate_file_meta
 from pydicom.encaps import itemize_frame
 from pydicom.filebase import DicomFile, DicomFileLike
@@ -442,6 +443,7 @@ class WsiDataset(Dataset):
                 name not in dataset
                 and not attribute.evaluate(image_flavor)
             ):
+                warnings.warn(f"Missing required attribute {name}")
                 return None
 
         syntax_supported = (

--- a/wsidicom/instance.py
+++ b/wsidicom/instance.py
@@ -997,8 +997,17 @@ class WsiDataset(Dataset):
         )
 
 
-class MetaWsiDicomFile(metaclass=ABCMeta):
+class WsiDicomFileBase():
     def __init__(self, filepath: Path, mode: str):
+        """Base class for reading or writing DICOM WSI file.
+
+        Parameters
+        ----------
+        filepath: Path
+            Filepath to file to read or write.
+        mode: str
+            Mode for opening file.
+        """
         self._filepath = filepath
         self._fp = DicomFile(filepath, mode=mode)
         self.__enter__()
@@ -1069,7 +1078,7 @@ class MetaWsiDicomFile(metaclass=ABCMeta):
         self._fp.close()
 
 
-class WsiDicomFile(MetaWsiDicomFile):
+class WsiDicomFile(WsiDicomFileBase):
     """Represents a DICOM file (potentially) containing WSI image and metadata.
     """
     def __init__(self, filepath: Path):
@@ -2869,7 +2878,7 @@ class SparseTileIndex(TileIndex):
         return tile, z
 
 
-class WsiDicomFileWriter(MetaWsiDicomFile):
+class WsiDicomFileWriter(WsiDicomFileBase):
     def __init__(self, filepath: Path) -> None:
         """Return a dicom filepointer.
 

--- a/wsidicom/instance.py
+++ b/wsidicom/instance.py
@@ -1273,7 +1273,7 @@ class ImageData(metaclass=ABCMeta):
     def tiled_size(self) -> Size:
         """The size of the image when divided into tiles, e.g. number of
         columns and rows of tiles. Equals (1, 1) if image is not tiled."""
-        return self.image_size / self.tile_size
+        return self.image_size.ceil_div(self.tile_size)
 
     @property
     def image_region(self) -> Region:
@@ -1711,7 +1711,7 @@ class ImageData(metaclass=ABCMeta):
             Region of tiles for stitching image
         """
         start = pixel_region.start // self.tile_size
-        end = pixel_region.end / self.tile_size - 1
+        end = pixel_region.end.ceil_div(self.tile_size) - 1
         tile_region = Region.from_points(start, end)
         if not self.valid_tiles(tile_region, z, path):
             raise WsiDicomOutOfBoundsError(
@@ -2133,7 +2133,7 @@ class TileIndex(metaclass=ABCMeta):
         self._tile_size = base_dataset.tile_size
         self._frame_count = self._read_frame_count_from_datasets(datasets)
         self._optical_paths = self._read_optical_paths_from_datasets(datasets)
-        self._tiled_size = self.image_size / self.tile_size
+        self._tiled_size = self.image_size.ceil_div(self.tile_size)
 
     def __str__(self) -> str:
         return (
@@ -2996,7 +2996,7 @@ class WsiDicomFileWriter(MetaWsiDicomFile):
             minimum_chunk_size,
             chunk_size//minimum_chunk_size * minimum_chunk_size
         )
-        new_tiled_size = image_data.tiled_size / scale
+        new_tiled_size = image_data.tiled_size.ceil_div(scale)
         # Divide the image tiles up into chunk_size chunks (up to tiled size)
         chunked_tile_points = (
             Region(

--- a/wsidicom/instance.py
+++ b/wsidicom/instance.py
@@ -244,15 +244,14 @@ class WsiDataset(Dataset):
         frame_of_reference_uid = self._get('FrameOfReferenceUID')
 
         slide_uids = SlideUids(
-
             self.StudyInstanceUID,
             self.SeriesInstanceUID,
             frame_of_reference_uid,
         )
         file_uids = FileUids(
-            self.instance_uid,
-            self.concatenation_uid,
-            self.slide_uids
+            instance_uid,
+            concatenation_uid,
+            slide_uids
         )
         return file_uids
 
@@ -496,19 +495,19 @@ class WsiDataset(Dataset):
     @property
     def instance_uid(self) -> UID:
         """Return instance uid from dataset."""
-        return self._instance_uid
+        return self.uids.instance
 
     @property
     def concatenation_uid(self) -> Optional[UID]:
         """Return concatenation uid, if defined, from dataset. An instance that
         is concatenated (split into several files) should have the same
         concatenation uid."""
-        return self._concatenation_uid
+        return self.uids.concatenation
 
     @property
     def slide_uids(self) -> SlideUids:
         """Return base uids (study, series, and frame of reference Uids)."""
-        return self._slide_uids
+        return self.uids.slide
 
     @property
     def uids(self) -> FileUids:
@@ -1222,7 +1221,7 @@ class WsiDicomFile(MetaWsiDicomFile):
                 valid_files.append(file)
             else:
                 warnings.warn(
-                    f'{file.filepath} with uids {file.uids.base} '
+                    f'{file.filepath} with uids {file.uids.slide} '
                     f'did not match series with {series_uids} '
                     f'and tile size {series_tile_size}'
                 )
@@ -3340,7 +3339,7 @@ class WsiInstance:
                 raise WsiDicomError("Datasets in instances does not match")
         return (
             base_dataset.uids.identifier,
-            base_dataset.uids.base,
+            base_dataset.uids.slide,
         )
 
     def matches(self, other_instance: 'WsiInstance') -> bool:

--- a/wsidicom/instance.py
+++ b/wsidicom/instance.py
@@ -583,10 +583,7 @@ class WsiDataset(Dataset):
         pixel_measure[0].SpacingBetweenSlices = (
             self._get_spacing_between_slices_for_focal_planes(focal_planes)
         )
-        # if dataset.spacing_between_slices is not None:
-        #     pixel_measure[0].SpacingBetweenSlices = (
-        #         dataset.spacing_between_slices
-        #     )
+
         if dataset.slice_thickness is not None:
             pixel_measure[0].SliceThickness = dataset.slice_thickness
 

--- a/wsidicom/uid.py
+++ b/wsidicom/uid.py
@@ -18,6 +18,7 @@ from typing import Optional
 from pydicom.uid import UID as Uid
 
 from wsidicom.config import settings
+from wsidicom.errors import WsiDicomStrictRequirementError
 
 WSI_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.77.1.6'
 ANN_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.91.1'
@@ -37,7 +38,7 @@ class SlideUids:
         frame_of_reference: Optional[Uid] = None
     ) -> None:
         if settings.strict_uid_check and frame_of_reference is None:
-            raise ValueError(
+            raise WsiDicomStrictRequirementError(
                 'Frame of reference uid is missing and strict uid check is '
                 'enabled'
             )

--- a/wsidicom/uid.py
+++ b/wsidicom/uid.py
@@ -15,27 +15,27 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from pydicom.uid import UID as Uid
+from pydicom.uid import UID
 
 from wsidicom.config import settings
 from wsidicom.errors import WsiDicomStrictRequirementError
 
-WSI_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.77.1.6'
-ANN_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.91.1'
+WSI_SOP_CLASS_UID = UID('1.2.840.10008.5.1.4.1.1.77.1.6')
+ANN_SOP_CLASS_UID = UID('1.2.840.10008.5.1.4.1.1.91.1')
 
 
 @dataclass
 class SlideUids:
     """Represents the UIDs that should be common for all files of a slide."""
-    study_instance: Uid
-    series_instance: Uid
-    frame_of_reference: Optional[Uid] = None
+    study_instance: UID
+    series_instance: UID
+    frame_of_reference: Optional[UID] = None
 
     def __init__(
         self,
-        study_instance: Uid,
-        series_instance: Uid,
-        frame_of_reference: Optional[Uid] = None
+        study_instance: UID,
+        series_instance: UID,
+        frame_of_reference: Optional[UID] = None
     ) -> None:
         if settings.strict_uid_check and frame_of_reference is None:
             raise WsiDicomStrictRequirementError(
@@ -79,12 +79,12 @@ class SlideUids:
 @dataclass
 class FileUids:
     """Represents the UIDs in a DICOM-file."""
-    instance: Uid
-    concatenation: Optional[Uid]
+    instance: UID
+    concatenation: Optional[UID]
     slide: SlideUids
 
     @property
-    def identifier(self) -> Uid:
+    def identifier(self) -> UID:
         """Return identifier for the instance the file belongs to. Either its
         own intance uid or, if not none, the concnatenation uid.
 

--- a/wsidicom/uid.py
+++ b/wsidicom/uid.py
@@ -80,7 +80,7 @@ class FileUids:
     """Represents the UIDs in a DICOM-file."""
     instance: Uid
     concatenation: Optional[Uid]
-    base: SlideUids
+    slide: SlideUids
 
     @property
     def identifier(self) -> Uid:
@@ -114,6 +114,6 @@ class FileUids:
             return (
                 self.concatenation is not None and
                 self.concatenation == other.concatenation and
-                self.base == other.base
+                self.slide == other.slide
             )
         return NotImplemented

--- a/wsidicom/wsidicom.py
+++ b/wsidicom/wsidicom.py
@@ -1594,9 +1594,8 @@ class WsiDicom:
                     wsi_file.close()
             elif sop_class_uid == ANN_SOP_CLASS_UID:
                 annotation_files.append(filepath)
-
         base_dataset = cls._get_base_dataset(level_files)
-        base_uids = base_dataset.base_uids
+        base_uids = base_dataset.uids.base
         base_tile_size = base_dataset.tile_size
         level_instances = WsiInstance.open(
             level_files,

--- a/wsidicom/wsidicom.py
+++ b/wsidicom/wsidicom.py
@@ -765,7 +765,7 @@ class WsiDicomLevel(WsiDicomGroup):
                 f"Region {cropped_region}", f"level size {self.size}"
             )
         image = self.get_region(cropped_region, z, path)
-        tile_size = cropped_region.size/scale
+        tile_size = cropped_region.size.ceil_div(scale)
         image = image.resize(
             tile_size.to_tuple(),
             resample=Image.BILINEAR


### PR DESCRIPTION
Make _get_-functions to simplify __init__ of WsiDataset-class.
Add image_type property to WsiAttribue class that can hold a tuple of strings to indicate what image types the requirement is valid for.
When saving multiple focal planes, check that they are not sparse and set correct spacing between slices.
