### PR TITLE
Set default chunk size to 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ...
+### Changed
+- Default chunk size for saving is now set to 16 tiles.
 
 ## [0.3.2] - 2022-05-08
 ### Fixed

--- a/wsidicom/wsidicom.py
+++ b/wsidicom/wsidicom.py
@@ -1953,7 +1953,7 @@ class WsiDicom:
             else:
                 workers = cpus
         if chunk_size is None:
-            chunk_size = 100
+            chunk_size = 16
 
         collections: List[WsiDicomSeries] = [
             self.levels, self.labels, self.overviews


### PR DESCRIPTION
Default chunk size of 100 seems to be to large for most formats. 