### PR TITLE
Allow loading multiple series with DICOMweb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make some arguments optional for `WsiDicomWebClient.create_client()`.
 - Removed `WsiDicomFileClient` since it is no longer needed.
 - Fetching multiple frames in one request instead of one request per frame when using DICOM Web.
+- Allow multiple series UIDs to be passed to `WsiDicom.open_web()`
+- Loosen UID matching to just `frame_of_reference`
+- Require equality of 'TotalPixelMatrixOriginSequence' when matching datasets
 
 ## [0.12.0] - 2023-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `WsiDicomFileClient` since it is no longer needed.
 - Fetching multiple frames in one request instead of one request per frame when using DICOM Web.
 - Allow multiple series UIDs to be passed to `WsiDicom.open_web()`.
-- Loosen UID matching to just `frame_of_reference`.
+- Loosen UID matching to just `study_instance`.
 - Require equality of 'TotalPixelMatrixOriginSequence' when matching datasets.
 
 ## [0.12.0] - 2023-10-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make some arguments optional for `WsiDicomWebClient.create_client()`.
 - Removed `WsiDicomFileClient` since it is no longer needed.
 - Fetching multiple frames in one request instead of one request per frame when using DICOM Web.
-- Allow multiple series UIDs to be passed to `WsiDicom.open_web()`
-- Loosen UID matching to just `frame_of_reference`
-- Require equality of 'TotalPixelMatrixOriginSequence' when matching datasets
+- Allow multiple series UIDs to be passed to `WsiDicom.open_web()`.
+- Loosen UID matching to just `frame_of_reference`.
+- Require equality of 'TotalPixelMatrixOriginSequence' when matching datasets.
 
 ## [0.12.0] - 2023-10-04
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ client = WsiDicomWebClient.create_client(
 slide = WsiDicom.open_web(
     client,
     "study uid to open",
-    "series uid top open"
+    "series uids top open"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ client = WsiDicomWebClient.create_client(
 slide = WsiDicom.open_web(
     client,
     "study uid to open",
-    "series uids top open"
+    "series uid to open" or ["series uid 1 to open", "series uid 2 to open"]
 )
 ```
 

--- a/wsidicom/instance/dataset.py
+++ b/wsidicom/instance/dataset.py
@@ -550,11 +550,14 @@ class WsiDataset(Dataset):
         bool
             True if same instance.
         """
+
         return (
             self.uids == other_dataset.uids
             and self.image_size == other_dataset.image_size
             and self.tile_size == other_dataset.tile_size
             and self.tile_type == other_dataset.tile_type
+            and (getattr(self, 'TotalPixelMatrixOriginSequence', None) ==
+                 getattr(other_dataset, 'TotalPixelMatrixOriginSequence', None))
         )
 
     def matches_series(self, uids: SlideUids, tile_size: Optional[Size] = None) -> bool:

--- a/wsidicom/uid.py
+++ b/wsidicom/uid.py
@@ -68,9 +68,12 @@ class SlideUids:
 
     def matches(self, other: "SlideUids") -> bool:
         if settings.strict_uid_check:
-            return self == other
+            return (
+                self.study_instance == other.study_instance
+                and self.frame_of_reference == other.frame_of_reference
+            )
 
-        return self.frame_of_reference == other.frame_of_reference
+        return self.study_instance == other.study_instance
 
 
 @dataclass

--- a/wsidicom/uid.py
+++ b/wsidicom/uid.py
@@ -70,10 +70,7 @@ class SlideUids:
         if settings.strict_uid_check:
             return self == other
 
-        return (
-            self.study_instance == other.study_instance
-            and self.series_instance == other.series_instance
-        )
+        return self.frame_of_reference == other.frame_of_reference
 
 
 @dataclass

--- a/wsidicom/web/wsidicom_web_source.py
+++ b/wsidicom/web/wsidicom_web_source.py
@@ -12,7 +12,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from collections import abc
 from typing import Iterable, List, Union
 
 from pydicom.uid import UID

--- a/wsidicom/web/wsidicom_web_source.py
+++ b/wsidicom/web/wsidicom_web_source.py
@@ -12,7 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import List, Union
+from collections import abc
+from typing import Iterable, List, Union
 
 from pydicom.uid import UID
 
@@ -33,7 +34,7 @@ class WsiDicomWebSource(Source):
         self,
         client: WsiDicomWebClient,
         study_uid: Union[str, UID],
-        series_uid: Union[str, UID],
+        series_uids: Union[str, UID, Iterable[Union[str, UID]]],
         requested_transfer_syntax: UID,
     ):
         """Create a WsiDicomWebSource.
@@ -44,8 +45,8 @@ class WsiDicomWebSource(Source):
             Client use for DICOMWeb communication.
         study_uid: Union[str, UID]
             Study UID of DICOM WSI to open.
-        series_uid: Union[str, UID]
-            Series UID of DICOM WSI top open.
+        series_uids: Union[str, UID, Iterable[Union[str, UID]]]
+            Series UIDs of DICOM WSI top open.
         requested_transfer_syntax: UID
             Transfer syntax to request for image data, for example
             UID("1.2.840.10008.1.2.4.50") for JPEGBaseline8Bit.
@@ -53,33 +54,42 @@ class WsiDicomWebSource(Source):
         """
         if not isinstance(study_uid, UID):
             study_uid = UID(study_uid)
-        if not isinstance(series_uid, UID):
-            series_uid = UID(series_uid)
+
+        if not isinstance(series_uids, abc.Iterable):
+            series_uids = [series_uids]
+
         self._level_instances: List[WsiInstance] = []
         self._label_instances: List[WsiInstance] = []
         self._overview_instances: List[WsiInstance] = []
-        for instance_uid in client.get_wsi_instances(study_uid, series_uid):
-            dataset = client.get_instance(study_uid, series_uid, instance_uid)
-            if not WsiDataset.is_supported_wsi_dicom(
-                dataset, requested_transfer_syntax
-            ):
-                continue
-            dataset = WsiDataset(dataset)
-            image_data = WsiDicomWebImageData(
-                client, dataset, requested_transfer_syntax
-            )
-            instance = WsiInstance(dataset, image_data)
-            if instance.image_type == ImageType.VOLUME:
-                self._level_instances.append(instance)
-            elif instance.image_type == ImageType.LABEL:
-                self._label_instances.append(instance)
-            elif instance.image_type == ImageType.OVERVIEW:
-                self._overview_instances.append(instance)
         self._annotation_instances: List[AnnotationInstance] = []
-        for instance_uid in client.get_ann_instances(study_uid, series_uid):
-            instance = client.get_instance(study_uid, series_uid, instance_uid)
-            annotation_instance = AnnotationInstance.open_dataset(instance)
-            self._annotation_instances.append(annotation_instance)
+
+        for series_uid in series_uids:
+            if not isinstance(series_uid, UID):
+                series_uid = UID(series_uid)
+
+            for instance_uid in client.get_wsi_instances(study_uid, series_uid):
+                dataset = client.get_instance(study_uid, series_uid, instance_uid)
+                if not WsiDataset.is_supported_wsi_dicom(
+                    dataset, requested_transfer_syntax
+                ):
+                    continue
+                dataset = WsiDataset(dataset)
+                image_data = WsiDicomWebImageData(
+                    client, dataset, requested_transfer_syntax
+                )
+                instance = WsiInstance(dataset, image_data)
+                if instance.image_type == ImageType.VOLUME:
+                    self._level_instances.append(instance)
+                elif instance.image_type == ImageType.LABEL:
+                    self._label_instances.append(instance)
+                elif instance.image_type == ImageType.OVERVIEW:
+                    self._overview_instances.append(instance)
+
+            for instance_uid in client.get_ann_instances(study_uid, series_uid):
+                instance = client.get_instance(study_uid, series_uid, instance_uid)
+                annotation_instance = AnnotationInstance.open_dataset(instance)
+                self._annotation_instances.append(annotation_instance)
+
         try:
             self._base_dataset = next(
                 instance.dataset

--- a/wsidicom/web/wsidicom_web_source.py
+++ b/wsidicom/web/wsidicom_web_source.py
@@ -55,7 +55,7 @@ class WsiDicomWebSource(Source):
         if not isinstance(study_uid, UID):
             study_uid = UID(study_uid)
 
-        if not isinstance(series_uids, abc.Iterable):
+        if isinstance(series_uids, (str, UID)):
             series_uids = [series_uids]
 
         self._level_instances: List[WsiInstance] = []

--- a/wsidicom/wsidicom.py
+++ b/wsidicom/wsidicom.py
@@ -121,7 +121,7 @@ class WsiDicom:
         cls,
         client: WsiDicomWebClient,
         study_uid: Union[str, UID],
-        series_uid: Union[str, UID],
+        series_uids: Union[str, UID, Iterable[Union[str, UID]]],
         requested_transfer_syntax: UID = JPEGBaseline8Bit,
         label: Optional[Union[PILImage, str, Path]] = None,
     ) -> "WsiDicom":
@@ -133,8 +133,8 @@ class WsiDicom:
             Configured DICOM web client.
         study_uid: Union[str, UID]
             Study uid of wsi to open.
-        series_uid: Union[str, UID]
-            Series uid of wsi to open
+        series_uids: Union[str, UID, Iterable[Union[str, UID]]]
+            Series uids of wsi to open
         transfer_syntax: UID
             Transfer syntax to request for image data, for example
             UID("1.2.840.10008.1.2.4.50") for JPEGBaseline8Bit.
@@ -147,7 +147,7 @@ class WsiDicom:
             WsiDicom created from WSI DICOM instances in study-series.
         """
         source = WsiDicomWebSource(
-            client, study_uid, series_uid, requested_transfer_syntax
+            client, study_uid, series_uids, requested_transfer_syntax
         )
         return cls(source, label, True)
 


### PR DESCRIPTION
`WsiDicom.open_web()` was modified to be able to either take a single series uid (as before) or a list of series uids. If a list of series uids is passed, their instances are all loaded together. This can be useful for cases where, for instance, different optical paths are located in different series.

This also loosens the UID matching to only check the frame of references.

This also adds `TotalPixelMatrixOriginSequence` matching when comparing datasets.

Fixes: #118

@erikogabrielsson Let me know what you think.