### PR TITLE
Resolves #173 Group instances into same pyramid if origin difference is below a threshold

### DIFF
--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -151,6 +151,13 @@ class TestPyramids:
                 ],
                 2,
             ],
+            [
+                [
+                    (PointMm(0, 0), Orientation((0, -1, 0, 1, 0, 0)), None),
+                    (PointMm(0.001, 0.001), Orientation((0, -1, 0, 1, 0, 0)), None),
+                ],
+                1,
+            ],
         ],
     )
     def test_open_number_of_created_pyramids(

--- a/tests/testdata/region_definitions.json
+++ b/tests/testdata/region_definitions.json
@@ -621,11 +621,73 @@
         "label": "692c84fcb25130abcb65169ec4f4d37f",
         "overview": "2274f918d7ca4b3f0951de77d1c48d04",
         "tiled": "sparse",
-        "read_region": [],
-        "read_region_mm": [],
-        "read_region_mpp": [],
-        "read_tile": [],
-        "read_encoded_tile": [],
-        "read_thumbnail": []
+        "read_region": [
+            {
+                "location": {
+                    "x": 800,
+                    "y": 500
+                },
+                "level": 4,
+                "size": {
+                    "width": 200,
+                    "height": 300
+                },
+                "md5": "de274a86b15ed4fca984f6619c6e5547"
+            }],
+        "read_region_mm": [
+            {
+                "location": {
+                    "x": 21.0,
+                    "y": 10.0
+                },
+                "level": 2,
+                "size": {
+                    "width": 1.0,
+                    "height": 2.0
+                },
+                "md5": "ec4e7d038f1de1021fcb3e0027f0105b"
+            }],
+        "read_region_mpp": [
+            {
+                "location": {
+                    "x": 21.0,
+                    "y": 10.0
+                },
+                "mpp": 8.0,
+                "size": {
+                    "width": 1.0,
+                    "height": 2.0
+                },
+                "md5": "439021d08a2e2fb755b1b65519eb2836"
+            }],
+        "read_tile": [
+            {
+                "location": {
+                    "x": 16,
+                    "y": 8
+                },
+                "level": 2,
+                "md5": "81e1da2f3e629e95f67aabb9dca67174"
+            }
+        ],
+        "read_encoded_tile": [
+            {
+                "location": {
+                    "x": 16,
+                    "y": 8
+                },
+                "level": 2,
+                "md5": "077ca7ea325beefc43ad7b057f1dd8ce"
+            }
+        ],
+        "read_thumbnail": [
+            {
+                "size": {
+                    "width": 512,
+                    "height": 512
+                },
+                "md5": "3a4d79e664225e1ea9b80c4e647f6b2c"
+            }
+        ]
     }
 }

--- a/wsidicom/config.py
+++ b/wsidicom/config.py
@@ -26,6 +26,7 @@ class Settings:
         self._strict_uid_check = False
         self._strict_attribute_check = False
         self._focal_plane_distance_threshold = 0.000001
+        self._pyramids_origin_threshold = 0.1
         self._prefered_decoder: Optional[str] = None
         self._open_web_theads: Optional[int] = None
         self._pillow_resampling_filter = Pillow.Resampling.BILINEAR
@@ -62,6 +63,17 @@ class Settings:
     @focal_plane_distance_threshold.setter
     def focal_plane_distance_threshold(self, value: float) -> None:
         self._focal_plane_distance_threshold = value
+
+    @property
+    def pyramids_origin_threshold(self) -> float:
+        """Threshold in mm for the distance between origins of instances
+        to group them into the same pyramid. Default is 1 mm.
+        """
+        return self._pyramids_origin_threshold
+
+    @pyramids_origin_threshold.setter
+    def pyramids_origin_threshold(self, value: float) -> None:
+        self._pyramids_origin_threshold = value
 
     @property
     def prefered_decoder(self) -> Optional[str]:


### PR DESCRIPTION
- new configurable setting `pyramids_origin_threshold`
- `wsidicom.series.pyramids.Pyramids` now groups instances into the same pyramid (greedily) if their origins differ slightly, using `pyramids_origin_threshold` as the threshold