### PR TITLE
Image type derived if resampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing of native pixel data with padded lenght.
 - Check for supported transfer syntax when DICOMWeb client returns an iterable of frames.
 - Fix for order of transfer syntax to check.
+- Use `ImageType` `DERIVED` instead of `ORIGINAL` when saving resampled volume instances.
 
 ## [0.21.4] - 2024-10-30
 

--- a/tests/metadata/dicom_schema/conftest.py
+++ b/tests/metadata/dicom_schema/conftest.py
@@ -139,7 +139,7 @@ def dicom_overview_label(label: Label):
 
 def create_dicom_label(label: Label, image_type: ImageType):
     dataset = Dataset()
-    dataset.ImageType = ["ORIGINAL", "PRIMIARY", image_type.value]
+    dataset.ImageType = ["ORIGINAL", "PRIMARY", image_type.value]
     if image_type == ImageType.LABEL:
         dataset.LabelText = label.text
         dataset.BarcodeValue = label.barcode

--- a/tests/test_wsi_dataset.py
+++ b/tests/test_wsi_dataset.py
@@ -270,7 +270,7 @@ class TestWsiDataset:
         ["image_type", "pyramid_index", "expected_image_type"],
         [
             (ImageType.VOLUME, 0, ["ORIGINAL", "PRIMARY", "VOLUME", "NONE"]),
-            (ImageType.VOLUME, 1, ["ORIGINAL", "PRIMARY", "VOLUME", "RESAMPLED"]),
+            (ImageType.VOLUME, 1, ["DERIVED", "PRIMARY", "VOLUME", "RESAMPLED"]),
             (ImageType.LABEL, None, ["ORIGINAL", "PRIMARY", "LABEL", "NONE"]),
             (ImageType.OVERVIEW, None, ["ORIGINAL", "PRIMARY", "OVERVIEW", "NONE"]),
         ],

--- a/wsidicom/instance/dataset.py
+++ b/wsidicom/instance/dataset.py
@@ -747,7 +747,12 @@ class WsiDataset(Dataset):
                 resampled = "RESAMPLED"
 
         original_or_derived = "ORIGINAL" if resampled == "NONE" else "DERIVED"
-        dataset.ImageType = [original_or_derived, "PRIMARY", image_type.value, resampled]
+        dataset.ImageType = [
+            original_or_derived,
+            "PRIMARY",
+            image_type.value,
+            resampled,
+        ]
         dataset.SOPInstanceUID = generate_uid(prefix=None)
         shared_functional_group_sequence = Dataset()
         if image_data.pixel_spacing is None:

--- a/wsidicom/instance/dataset.py
+++ b/wsidicom/instance/dataset.py
@@ -746,7 +746,8 @@ class WsiDataset(Dataset):
             if pyramid_index > 0:
                 resampled = "RESAMPLED"
 
-        dataset.ImageType = ["ORIGINAL", "PRIMARY", image_type.value, resampled]
+        original_or_derived = "ORIGINAL" if resampled == "NONE" else "DERIVED"
+        dataset.ImageType = [original_or_derived, "PRIMARY", image_type.value, resampled]
         dataset.SOPInstanceUID = generate_uid(prefix=None)
         shared_functional_group_sequence = Dataset()
         if image_data.pixel_spacing is None:


### PR DESCRIPTION
Resolves #175 

Use image type "DERIVED" instead of "ORIGINAL" if they are "RESAMPLED".
This is required by openslide to load it.

Links:
[Issue at openslide](https://github.com/openslide/openslide/issues/642)
[DICOM standard](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.12.4.html#sect_C.8.12.4.1.1), where the description in Table C.8.12.4-3. seems to indicate that resampling should be considered a form of derivation.