### PR TITLE
Fix lossy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Setting of `LossyImageCompression`, `LossyImageCompressionRatio`, and `LossyImageCompressionMethod` when image data requires transcoding.
+
 ## [0.23.0] - 2025-01-29
 
 ### Added

--- a/tests/file/io/test_wsidicom_writer.py
+++ b/tests/file/io/test_wsidicom_writer.py
@@ -32,7 +32,7 @@ from pydicom.uid import (
     generate_uid,
 )
 
-from wsidicom.codec import LossyCompressionIsoStandard
+from wsidicom.codec import Encoder, LossyCompressionIsoStandard
 from wsidicom.file.io import (
     OffsetTableType,
     WsiDicomIO,
@@ -153,6 +153,10 @@ class WsiDicomTestImageData(ImageData):
     def lossy_compression(
         self,
     ) -> Optional[List[Tuple[LossyCompressionIsoStandard, float]]]:
+        return None
+
+    @property
+    def transcoder(self) -> Optional[Encoder]:
         return None
 
     @property

--- a/wsidicom/file/wsidicom_file_target.py
+++ b/wsidicom/file/wsidicom_file_target.py
@@ -219,29 +219,34 @@ class WsiDicomFileTarget(Target):
                 focal_planes, optical_paths, tiled_size, scale
             )
             if self._transcoder is not None:
+                transcoder = self._transcoder
+            elif instances[0].image_data.transcoder is not None:
+                transcoder = instances[0].image_data.transcoder
+            else:
+                transcoder = None
+            if transcoder is not None:
                 if (
-                    self._transcoder.bits != instances[0].image_data.bits
-                    or self._transcoder.samples_per_pixel
+                    transcoder.bits != instances[0].image_data.bits
+                    or transcoder.samples_per_pixel
                     != instances[0].image_data.samples_per_pixel
                 ):
                     raise ValueError(
                         "Transcode settings must match image data bits and "
                         "photometric interpretation."
                     )
-                transfer_syntax = self._transcoder.transfer_syntax
+                transfer_syntax = transcoder.transfer_syntax
                 dataset.PhotometricInterpretation = (
-                    self._transcoder.photometric_interpretation
+                    transcoder.photometric_interpretation
                 )
-                if self._transcoder.lossy_method:
+                if transcoder.lossy_method:
                     dataset.LossyImageCompression = "01"
                     ratios = dataset.get_multi_value(LossyImageCompressionRatioTag)
                     # Reserve space for new ratio
                     ratios.append(" " * MAX_VALUE_LEN["DS"])
                     methods = dataset.get_multi_value(LossyImageCompressionMethodTag)
-                    methods.append(self._transcoder.lossy_method.value)
+                    methods.append(transcoder.lossy_method.value)
                     dataset.LossyImageCompressionRatio = ratios
                     dataset.LossyImageCompressionMethod = methods
-
             else:
                 transfer_syntax = instances[0].image_data.transfer_syntax
             if self._offset_table is not None:
@@ -261,7 +266,7 @@ class WsiDicomFileTarget(Target):
                     self._chunk_size,
                     self._instance_number,
                     scale,
-                    self._transcoder,
+                    transcoder,
                 )
             filepaths.append(filepath)
             self._instance_number += 1

--- a/wsidicom/instance/image_data.py
+++ b/wsidicom/instance/image_data.py
@@ -124,6 +124,13 @@ class ImageData(metaclass=ABCMeta):
         ratio is unknown."""
         raise NotImplementedError()
 
+    @property
+    @abstractmethod
+    def transcoder(self) -> Optional[Encoder]:
+        """Return transcoder used for image data if image data can't read encoded data
+        directly. Return None if no transcoder is needed."""
+        raise NotImplementedError()
+
     @abstractmethod
     def _get_decoded_tile(self, tile_point: Point, z: float, path: str) -> Image:
         """

--- a/wsidicom/instance/pillow_image_data.py
+++ b/wsidicom/instance/pillow_image_data.py
@@ -95,6 +95,10 @@ class PillowImageData(ImageData):
         compressed_size = len(self._get_encoded_tile(Point(0, 0), 0, ""))
         return [(iso, uncompressed_size / compressed_size)]
 
+    @property
+    def transcoder(self) -> Optional[Encoder]:
+        return None
+
     def _get_decoded_tile(self, tile_point: Point, z: float, path: str) -> Image:
         if tile_point != Point(0, 0):
             raise ValueError("Can only get Point(0, 0) from non-tiled image.")

--- a/wsidicom/instance/wsidicom_image_data.py
+++ b/wsidicom/instance/wsidicom_image_data.py
@@ -19,7 +19,7 @@ from typing import Iterator, List, Optional, Sequence, Tuple
 from PIL.Image import Image
 
 from wsidicom.cache import DecodedFrameCache, EncodedFrameCache
-from wsidicom.codec import Codec, Decoder, LossyCompressionIsoStandard
+from wsidicom.codec import Codec, Decoder, Encoder, LossyCompressionIsoStandard
 from wsidicom.errors import WsiDicomOutOfBoundsError
 from wsidicom.geometry import Point, Region, Size, SizeMm
 from wsidicom.instance.dataset import TileType, WsiDataset
@@ -116,10 +116,6 @@ class WsiDicomImageData(ImageData, metaclass=ABCMeta):
         """Return samples per pixel (1 or 3)."""
         return self._datasets[0].samples_per_pixel
 
-    # @property
-    # def lossy_compressed(self) -> bool:
-    #     return self._datasets[0].lossy_compressed
-
     @cached_property
     def image_coordinate_system(self) -> Optional[ImageCoordinateSystem]:
         """Return the image origin of the image data."""
@@ -152,6 +148,10 @@ class WsiDicomImageData(ImageData, metaclass=ABCMeta):
             )
         ]
         return list(zip(methods, ratios))
+
+    @property
+    def transcoder(self) -> Optional[Encoder]:
+        return None
 
     @property
     def decoder(self) -> Decoder:


### PR DESCRIPTION
- Add property `transcoder` to image data to indicate that the image data requires transcoding to read byte tiles.
- Set lossy compression, ratio, and method based if user request transcoding or if image requires transcoding.