### PR TITLE
Thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for using instances of `THUMBNAIL` image flavor. If found these are grouped together with the corresponding pyramid, and possible used as image data in `read_thumbnail`.
+
 ## [0.23.0] - 2025-01-29
 
 ### Added

--- a/tests/file/test_wsidicom_file_target_integration.py
+++ b/tests/file/test_wsidicom_file_target_integration.py
@@ -152,7 +152,7 @@ class TestWsiDicomFileTargetIntegration:
             if level.size.any_greater_than(wsi.pyramids[0].tile_size)
         ]
         expected_levels_count = len(levels_larger_than_tile_size) + 1
-        pyramid_missing_smallest_levels = Pyramid(levels_larger_than_tile_size)
+        pyramid_missing_smallest_levels = Pyramid(levels_larger_than_tile_size, [])
         pyramids = Pyramids([pyramid_missing_smallest_levels])
 
         # Act

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -185,7 +185,7 @@ class TestPyramids:
         ]
 
         # Act
-        pyramids = Pyramids.open(instances)
+        pyramids = Pyramids.open(instances, [])
 
         # Assert
         assert len(pyramids) == expected_pyramid_count

--- a/tests/test_wsidicom_integration.py
+++ b/tests/test_wsidicom_integration.py
@@ -187,6 +187,8 @@ class TestWsiDicomIntegration:
         # Assert
         checksum = md5(im.tobytes()).hexdigest()
         assert checksum == region["md5"], (region, checksum)
+        assert im.size[0] <= region["size"]["width"]
+        assert im.size[1] <= region["size"]["height"]
 
     @pytest.mark.parametrize(
         ["wsi_name", "expected_level_count"], WsiTestDefinitions.levels()

--- a/tests/test_wsidicom_levels.py
+++ b/tests/test_wsidicom_levels.py
@@ -59,7 +59,7 @@ class TestWsiDicomLevels:
         closest_level = wsi.pyramids[0].get_closest_by_size(Size(100, 100))
 
         # Assert
-        assert closest_level.level == 0
+        assert closest_level == wsi.pyramids[0].base_level
 
     def test_calculate_scale(self, wsi: WsiDicom):
         # Arrange

--- a/tests/testdata/region_definitions.json
+++ b/tests/testdata/region_definitions.json
@@ -539,7 +539,7 @@
                     "width": 512,
                     "height": 512
                 },
-                "md5": "e9ab4d977293f7739aee97e9ee615cbd"
+                "md5": "cb0b85cd7662b7cc4433d5baf7a36f1d"
             }
         ]
     },
@@ -623,7 +623,7 @@
                     "width": 512,
                     "height": 512
                 },
-                "md5": "e523be62bcdbf7d41d0c53912d120e9a"
+                "md5": "ee3c31ed08bb3604b2816fc633b1062e"
             }
         ]
     },

--- a/wsidicom/file/wsidicom_file_source.py
+++ b/wsidicom/file/wsidicom_file_source.py
@@ -62,6 +62,7 @@ class WsiDicomFileSource(Source):
         self._levels: List[WsiDicomReader] = []
         self._labels: List[WsiDicomReader] = []
         self._overviews: List[WsiDicomReader] = []
+        self._thumbnails: List[WsiDicomReader] = []
         self._annotations: List[WsiDicomIO] = []
         for stream in streams:
             try:
@@ -74,6 +75,8 @@ class WsiDicomFileSource(Source):
                             self._labels.append(reader)
                         elif reader.image_type == ImageType.OVERVIEW:
                             self._overviews.append(reader)
+                        elif reader.image_type == ImageType.THUMBNAIL:
+                            self._thumbnails.append(reader)
                     except WsiDicomNotSupportedError:
                         logging.info(f"Non-supported file {stream}.")
                         if stream.owned:
@@ -114,6 +117,11 @@ class WsiDicomFileSource(Source):
     def overview_instances(self) -> Iterable[WsiInstance]:
         """The overview instances parsed from the source."""
         return self._create_instances(self._overviews, self._slide_uids)
+
+    @property
+    def thumbnail_instances(self) -> Iterable[WsiInstance]:
+        """The thumbnail instances parsed from the source."""
+        return self._create_instances(self._thumbnails, self._slide_uids)
 
     @property
     def annotation_instances(self) -> Iterable[AnnotationInstance]:

--- a/wsidicom/file/wsidicom_file_source.py
+++ b/wsidicom/file/wsidicom_file_source.py
@@ -138,6 +138,7 @@ class WsiDicomFileSource(Source):
             self._levels,
             self._labels,
             self._overviews,
+            self._thumbnails,
         ]
         return [reader for reader_list in reader_lists for reader in reader_list]
 

--- a/wsidicom/file/wsidicom_file_target.py
+++ b/wsidicom/file/wsidicom_file_target.py
@@ -162,6 +162,7 @@ class WsiDicomFileTarget(Target):
             if pyramid_level in pyramid.pyramid_indices:
                 level = pyramid.get(pyramid_level)
                 self._save_group(level, 1)
+
             elif self._add_missing_levels:
                 # Create scaled level from closest level, prefer from original levels
                 closest_level = pyramid.get_closest_by_level(pyramid_level)
@@ -185,6 +186,9 @@ class WsiDicomFileTarget(Target):
                     scale,
                 )
                 new_levels.append(new_level)
+        if pyramid.thumbnails is not None:
+            for group in pyramid.thumbnails.groups:
+                self._save_group(group, 1)
 
     def _save_and_open_level(
         self,

--- a/wsidicom/instance/dataset.py
+++ b/wsidicom/instance/dataset.py
@@ -48,6 +48,7 @@ class ImageType(Enum):
     VOLUME = "VOLUME"
     LABEL = "LABEL"
     OVERVIEW = "OVERVIEW"
+    THUMBNAIL = "THUMBNAIL"
 
 
 class Requirement(IntEnum):

--- a/wsidicom/metadata/image.py
+++ b/wsidicom/metadata/image.py
@@ -183,8 +183,10 @@ class ImageCoordinateSystem:
         )
 
     def origin_and_rotation_match(
-        self, other: "ImageCoordinateSystem", origin_threshold: float
+        self, other: Optional["ImageCoordinateSystem"], origin_threshold: float
     ) -> bool:
+        if other is None:
+            return False
         if self.rotation != other.rotation:
             return False
         origin_distance = sqrt(

--- a/wsidicom/series/series.py
+++ b/wsidicom/series/series.py
@@ -13,8 +13,8 @@
 #    limitations under the License.
 
 from abc import ABCMeta, abstractmethod
-from functools import cached_property
 from collections import defaultdict
+from functools import cached_property
 from typing import (
     Dict,
     Generic,
@@ -26,7 +26,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
 
 from wsidicom.errors import WsiDicomMatchError, WsiDicomNotFoundError
 from wsidicom.geometry import Size, SizeMm
@@ -150,6 +149,33 @@ class Series(Generic[GroupType], metaclass=ABCMeta):
             return None
         return cls(groups)
 
+    def get_closest_by_size(self, size: Size) -> Optional[Group]:
+        """Search for group that by size is closest to and larger than the
+        given size.
+
+        Parameters
+        ----------
+        size: Size
+            The size to search for
+
+        Returns
+        -------
+        Optional[Group]
+            The group with size closest to searched size, or None if no group is
+            larger than or equal to the searched size.
+        """
+        if len(self._groups) == 0:
+            return None
+        closest_size = self._groups[0].size
+        closest = None
+        for wsi_level in self._groups:
+            if (size.width <= wsi_level.size.width) and (
+                wsi_level.size.width <= closest_size.width
+            ):
+                closest_size = wsi_level.size
+                closest = wsi_level
+        return closest
+
     @classmethod
     def _group_instances_by_size(
         cls, instances: Iterable[WsiInstance]
@@ -222,3 +248,11 @@ class Labels(Series[Group]):
     @property
     def image_type(self) -> ImageType:
         return ImageType.LABEL
+
+
+class Thumbnails(Series[Group]):
+    """Represents a series of Groups of the thumbnail wsi flavor."""
+
+    @property
+    def image_type(self) -> ImageType:
+        return ImageType.THUMBNAIL

--- a/wsidicom/source.py
+++ b/wsidicom/source.py
@@ -68,6 +68,12 @@ class Source(metaclass=ABCMeta):
 
     @property
     @abstractmethod
+    def thumbnail_instances(self) -> Iterable[WsiInstance]:
+        """Return all thumbnail instances from the source."""
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
     def annotation_instances(self) -> Iterable[AnnotationInstance]:
         """Return all annotation instances from the source."""
         raise NotImplementedError()

--- a/wsidicom/web/wsidicom_web_source.py
+++ b/wsidicom/web/wsidicom_web_source.py
@@ -84,6 +84,7 @@ class WsiDicomWebSource(Source):
         self._level_instances: List[WsiInstance] = []
         self._label_instances: List[WsiInstance] = []
         self._overview_instances: List[WsiInstance] = []
+        self._thumbnail_instances: List[WsiInstance] = []
         self._annotation_instances: List[AnnotationInstance] = []
         detected_transfer_syntaxes_by_image_type: Dict[ImageType, Set[UID]] = (
             defaultdict(set)
@@ -147,6 +148,8 @@ class WsiDicomWebSource(Source):
                     self._label_instances.append(instance)
                 elif instance.image_type == ImageType.OVERVIEW:
                     self._overview_instances.append(instance)
+                elif instance.image_type == ImageType.THUMBNAIL:
+                    self._thumbnail_instances.append(instance)
             for annotation_instance in annotation_instances:
                 self._annotation_instances.append(
                     AnnotationInstance.open_dataset(annotation_instance)
@@ -193,6 +196,11 @@ class WsiDicomWebSource(Source):
     def overview_instances(self) -> List[WsiInstance]:
         """The overview instances parsed from the source."""
         return self._overview_instances
+
+    @property
+    def thumbnail_instances(self) -> List[WsiInstance]:
+        """The thumbnail instances parsed from the source."""
+        return self._thumbnail_instances
 
     @property
     def annotation_instances(self) -> List[AnnotationInstance]:

--- a/wsidicom/wsidicom.py
+++ b/wsidicom/wsidicom.py
@@ -44,6 +44,7 @@ from wsidicom.errors import (
 from wsidicom.file import OffsetTableType, WsiDicomFileSource, WsiDicomFileTarget
 from wsidicom.geometry import Point, PointMm, Region, RegionMm, Size, SizeMm
 from wsidicom.graphical_annotations import AnnotationInstance
+from wsidicom.group.group import Group
 from wsidicom.instance import WsiDataset, WsiInstance
 from wsidicom.metadata.wsi import WsiMetadata
 from wsidicom.series import Labels, Overviews, Pyramid, Pyramids
@@ -511,6 +512,7 @@ class WsiDicom:
         z: Optional[float] = None,
         path: Optional[str] = None,
         pyramid: Optional[int] = None,
+        force_generate: bool = False,
     ) -> Image:
         """Read thumbnail image of the whole slide with dimensions no larger than given
         size.
@@ -526,6 +528,9 @@ class WsiDicom:
         pyramid: Optional[int] = None
             Pyramid to read thumbnail from. If `None` the index in `selected_pyramid` is
             used.
+        force_generate: bool = False
+            If to force generation of thumbnail from levels, even if thumbnail image is
+            present for levels.
 
         Returns
         -------
@@ -536,7 +541,8 @@ class WsiDicom:
             size = (size, size)
         thumbnail_size = Size.from_tuple(size)
         selected_pyramid = self.pyramids.get(pyramid or self.selected_pyramid)
-        if selected_pyramid.thumbnails is not None:
+        thumbnail: Optional[Group] = None
+        if not force_generate and selected_pyramid.thumbnails is not None:
             thumbnail = selected_pyramid.thumbnails.get_closest_by_size(thumbnail_size)
         if selected_pyramid.thumbnails is None or thumbnail is None:
             thumbnail = selected_pyramid.get_closest_by_size(thumbnail_size)


### PR DESCRIPTION
- Read thumbnail instances from source.
- Add thumbnails to matching pyramid.
- Use thumbnails in pyramid for `read_thumbnail()` if available.
- Save thumbnails when saving pyramid.